### PR TITLE
Add tutorial for notes app to docs site

### DIFF
--- a/website/docs/tutorial-build-a-simple-notes-app.md
+++ b/website/docs/tutorial-build-a-simple-notes-app.md
@@ -1,0 +1,7 @@
+---
+title: Build a simple notes app
+---
+
+This tutorial will show you how to build a simple note taking application where users own their data with IDX and React.
+
+[Start building >](https://blog.ceramic.network/how-to-build-a-simple-notes-app-with-idx/)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -3,5 +3,6 @@ module.exports = {
     'Identity Index': ['idx-introduction', 'idx-terminology', 'idx-ecosystem'],
     'IDX libraries': ['libs-getting-started', 'libs-types', 'libs-tools', 'libs-idx', 'libs-web'],
     Guides: ['guide-cli', 'guide-public-data', 'guide-authentication', 'guide-definitions']
+    Tutorials: ['tutorial-build-a-simple-notes-app']
   }
 }


### PR DESCRIPTION
This PR does 2 things:
1. Adds a `Tutorials` category to sidebar.js
2. Adds a page within tutorials for the new notes app tutorial. It's light and just more or less links to the blog page.