### PR TITLE
fix: pin root document

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@ceramicstudio/idx",
   "author": "Ceramic Studio",
   "homepage": "https://idx.xyz",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "(Apache-2.0 OR MIT)",
   "main": "dist/index.js",
   "module": "dist/idx.esm.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,7 +178,7 @@ export class IDX {
   }
 
   async _createIDXDoc(did: string): Promise<Doctype> {
-    return await this._ceramic.createDocument(
+    const doc = await this._ceramic.createDocument(
       'tile',
       {
         deterministic: true,
@@ -186,6 +186,10 @@ export class IDX {
       },
       { anchor: false, publish: false }
     )
+    if (this._autopin) {
+      await this._ceramic.pin.add(doc.id)
+    }
+    return doc
   }
 
   async _getIDXDoc(did: string): Promise<Doctype | null> {

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -223,9 +223,10 @@ describe('IDX', () => {
     })
 
     test('_createIDXDoc', async () => {
-      const doc = {}
+      const doc = { id: 'docId' }
+      const add = jest.fn()
       const createDocument = jest.fn(() => Promise.resolve(doc)) as any
-      const idx = new IDX({ ceramic: { createDocument } } as any)
+      const idx = new IDX({ ceramic: { createDocument, pin: { add } } } as any)
 
       await expect(idx._createIDXDoc('did:test:123')).resolves.toBe(doc)
       expect(createDocument).toHaveBeenCalledTimes(1)
@@ -237,6 +238,7 @@ describe('IDX', () => {
         },
         { anchor: false, publish: false }
       )
+      expect(add).toBeCalledWith('docId')
     })
 
     describe('_getIDXDoc', () => {


### PR DESCRIPTION
The root IDX document was not getting pinned. This PR fixes this if autopin is true.

`next` release: `@ceramicstudio/idx@0.5.2-beta.1`